### PR TITLE
Few refinements to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,16 +7,13 @@ cross-compilation toolchain from Linux.  Usage:
 
 ```
 	git clone https://github.com/SWI-Prolog/swipl-devel.git
-        cd swipl-devel
-	git submodule update --init
-	cd ..
+        git -C swipl-devel submodule update --init
 ```
   - Setup docker-swipl-build-mingw
 
 ```
 	git clone https://github.com/SWI-Prolog/docker-swipl-build-mingw.git
-	cd docker-swipl-build-mingw
-	git submodule update --init
+	git -C docker-swipl-build-mingw submodule update --init
 ```
   - Edit `Makefile` to make $SWIPLSRC point at a checked out source tree
     normally obtained using

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This  docker  builds   SWI-Prolog   for    Windows   using   the   MinGW
 cross-compilation toolchain from Linux.  Usage:
 
-  - Get source tree if you don't have them already
+  - Get source tree if you don't have it already
 
 ```
 	git clone https://github.com/SWI-Prolog/swipl-devel.git

--- a/README.md
+++ b/README.md
@@ -10,7 +10,12 @@ cross-compilation toolchain from Linux.  Usage:
 	git clone https://github.com/SWI-Prolog/swipl-devel.git
 	git submodule update --init
 ```
+  - Update submodules 
 
+```
+	cd docker-swipl-builg-mingw
+	git submodule update --init
+```
   - By default, the Docker image creates a user `swipl` with the UID and
     GID of the user that creates the image.  This user/group is used for
     the build process.  Edit GID and UID in Makefile if you want a

--- a/README.md
+++ b/README.md
@@ -3,17 +3,26 @@
 This  docker  builds   SWI-Prolog   for    Windows   using   the   MinGW
 cross-compilation toolchain from Linux.  Usage:
 
+  - Get source tree if you don't have them already
+
+```
+	git clone https://github.com/SWI-Prolog/swipl-devel.git
+        cd swipl-devel
+	git submodule update --init
+	cd ..
+```
+  - Setup docker-swipl-build-mingw
+
+```
+	git clone https://github.com/SWI-Prolog/docker-swipl-build-mingw.git
+	cd docker-swipl-build-mingw
+	git submodule update --init
+```
   - Edit `Makefile` to make $SWIPLSRC point at a checked out source tree
     normally obtained using
 
 ```
 	git clone https://github.com/SWI-Prolog/swipl-devel.git
-	git submodule update --init
-```
-  - Update submodules 
-
-```
-	cd docker-swipl-builg-mingw
 	git submodule update --init
 ```
   - By default, the Docker image creates a user `swipl` with the UID and


### PR DESCRIPTION
The docker-swipl-build-mingw repository now has submodules (pywine), added instruction to init that

Instructing how to get the swipl-devel source tree from github